### PR TITLE
W3 standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ Postman 사진
 동작 다이어그램 사진
 <img src="https://github.com/user-attachments/assets/32aadec7-3b31-4796-adf6-f0f677c37072" alt="spring RestController flow diagram">
 </details>
+</br>
+
+<details>
+<summary>spring 3주차 세션 과제 사진</summary>
+DB 반영 인증샷 ✌
+<img src="https://github.com/user-attachments/assets/77ec99bd-287a-41cc-9a2e-61106a95a8e5
+" alt="DB photo">
+</details>

--- a/README.md
+++ b/README.md
@@ -13,6 +13,5 @@ Postman 사진
 <details>
 <summary>spring 3주차 세션 과제 사진</summary>
 DB 반영 인증샷 ✌
-<img src="https://github.com/user-attachments/assets/77ec99bd-287a-41cc-9a2e-61106a95a8e5
-" alt="DB photo">
+<img src="https://github.com/user-attachments/assets/77ec99bd-287a-41cc-9a2e-61106a95a8e5" alt="DB photo">
 </details>

--- a/session/src/main/java/likelion12th/session/domain/Member.java
+++ b/session/src/main/java/likelion12th/session/domain/Member.java
@@ -1,12 +1,7 @@
 package likelion12th.session.domain;
 
 import jakarta.persistence.*;
-import likelion12th.session.domain.music.Like;
-import likelion12th.session.domain.music.Playlist;
 import lombok.*;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import static jakarta.persistence.GenerationType.*;
 

--- a/session/src/main/java/likelion12th/session/domain/Member.java
+++ b/session/src/main/java/likelion12th/session/domain/Member.java
@@ -1,17 +1,19 @@
 package likelion12th.session.domain;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import likelion12th.session.domain.music.Like;
+import likelion12th.session.domain.music.Playlist;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.GenerationType.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity{
     @Id
     @GeneratedValue(strategy = IDENTITY)
     @Column(name = "member_id")

--- a/session/src/main/java/likelion12th/session/domain/music/Album.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Album.java
@@ -1,0 +1,22 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import likelion12th.session.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Album extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "album_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/Artist.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Artist.java
@@ -1,0 +1,17 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Artist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "artist_id")
+    private Long id;
+    private String name;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/Genre.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Genre.java
@@ -1,0 +1,18 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Genre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "genre_id")
+    private Long id;
+    private String name;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/Like.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Like.java
@@ -1,0 +1,25 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import likelion12th.session.domain.Member;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Like {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "song_id")
+    private Song song;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/Likes.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Likes.java
@@ -2,13 +2,14 @@ package likelion12th.session.domain.music;
 
 import jakarta.persistence.*;
 import likelion12th.session.domain.Member;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
-public class Like {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Likes {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/session/src/main/java/likelion12th/session/domain/music/Playlist.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Playlist.java
@@ -1,0 +1,24 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import likelion12th.session.domain.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class Playlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "playlist_id")
+    private Long id;
+    private String title;
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/Song.java
+++ b/session/src/main/java/likelion12th/session/domain/music/Song.java
@@ -1,0 +1,27 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import likelion12th.session.domain.BaseTimeEntity;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Song extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "song_id")
+    private Long id;
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artist_id")
+    private Artist artist;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "album_id")
+    private Album album;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/SongGenre.java
+++ b/session/src/main/java/likelion12th/session/domain/music/SongGenre.java
@@ -15,9 +15,9 @@ public class SongGenre {
     @Column(name = "song_genre_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Song song;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Genre genre;
 }

--- a/session/src/main/java/likelion12th/session/domain/music/SongGenre.java
+++ b/session/src/main/java/likelion12th/session/domain/music/SongGenre.java
@@ -1,0 +1,23 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SongGenre {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "song_genre_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Song song;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Genre genre;
+}

--- a/session/src/main/java/likelion12th/session/domain/music/SongPlaylist.java
+++ b/session/src/main/java/likelion12th/session/domain/music/SongPlaylist.java
@@ -1,0 +1,24 @@
+package likelion12th.session.domain.music;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class SongPlaylist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "song_playlist_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "song_id")
+    private Song song;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "playlist_id")
+    private Playlist playlist;
+}


### PR DESCRIPTION
## 3주차 스탠다드 과제: 엔티티 설계 
- Member
- Song
- Album
- Artist
- Playlist
- Like
- Genre

### 🎈 Notes
- 세션 시간에 배운 단방향 연관 관계와 양방향 연관 관계 중 어떤 방식을 사용하는 것이 더 좋은 설계인가 고민했다. 결론부터 말하자면 실무에서 대부분은 단방향 참조를 사용하고 있다. 그 이유는 양방향 참조에서 발생할 수 있는 비효율적인 메모리 관리와 무한 루프 등의 문제 상황을 예방할 수 있기 때문이었다.
- 다:다 연관 관계를 가지는 경우 `@ManyToMany` 어노테이션을 사용할 수 있지만 중간 테이블을 만들어서 사용하자. 양쪽 테이블의 PK말고 다른 정보가 추가되어야 하는 경우가 있을 수 있기 때문에 1:다, 다:1로 풀어낸 중간 테이블을 만드는 것이 관리에 용이하고 수정에 쉽게 대응할 수 있다.
- `Like` 명령어는 예약어이기 때문에 테이블명으로 사용할 수 없음. 세션 시간에 하영쌤이 언급한 `Order`와 같은 케이스. 따라서 뒤에 s를 붙인 `Likes`를 테이블명으로 사용함.